### PR TITLE
FEAT: custom datalink button for opspilot integrations

### DIFF
--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -15,6 +15,7 @@ import {
 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { ClipboardButton, DataLinkButton, IconButton, Themeable2, withTheme2 } from '@grafana/ui';
+import { OpspilotDataLinkButton } from 'app/intergral/OpspilotDataLinkButton';
 
 import { logRowToSingleRowDataFrame } from '../logsModel';
 
@@ -323,7 +324,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
               <div className={cx((singleVal || isMultiParsedValueWithNoContent) && styles.adjoiningLinkButton)}>
                 {links?.map((link, i) => (
                   <span key={`${link.title}-${i}`}>
-                    <DataLinkButton link={link} />
+                    {link.title === "OpsPilot AI" ? <OpspilotDataLinkButton link={link} /> : <DataLinkButton link={link} />}  
                   </span>
                 ))}
               </div>

--- a/public/app/intergral/OpspilotDataLinkButton.tsx
+++ b/public/app/intergral/OpspilotDataLinkButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+// import { Field, LinkModel } from '@grafana/data';
+
+import { ButtonProps, Button } from '@grafana/ui';
+
+type DataLinkButtonProps = {
+  link: any;
+  buttonProps?: ButtonProps;
+};
+
+/**
+ * @internal
+ */
+export function OpspilotDataLinkButton({ link, buttonProps }: DataLinkButtonProps) {
+  return (
+      <Button
+        icon={link.target === '_blank' ? 'external-link-alt' : undefined}
+        variant="primary"
+        size="sm"
+        onClick={() => {
+          if (window.parent !== window) {
+            const integration = {content: link.href, content_type: "log"}
+            window.parent.postMessage({type: "opspilot-slave.sendIntegration", integration } , "*")
+          }
+        }}
+        {...buttonProps}
+      >
+        {link.title}
+      </Button>
+  );
+}


### PR DESCRIPTION
In order to remove the old opspilot app in grafana we need a custom datalink component. the grafana app is no longer being actively worked on by the team. 

this change is not approved yet and the rest of the stack needs updating to support it.
